### PR TITLE
Fix crashes: null bounds and SOCKS proxy

### DIFF
--- a/clawd-on-desk/src/minicpm-chat.js
+++ b/clawd-on-desk/src/minicpm-chat.js
@@ -445,6 +445,18 @@ class Sidecar {
       MINICPM_PARENT_PID: String(process.pid),
     };
 
+    // Strip proxy environment variables to avoid socksio dependency issues.
+    // The sidecar only makes local HTTP calls (localhost:18766) and downloads
+    // from HuggingFace (which has its own proxy handling via huggingface_hub).
+    const proxyVars = [
+      "http_proxy", "https_proxy", "ftp_proxy", "socks_proxy",
+      "HTTP_PROXY", "HTTPS_PROXY", "FTP_PROXY", "SOCKS_PROXY",
+      "all_proxy", "ALL_PROXY",
+    ];
+    for (const v of proxyVars) {
+      delete env[v];
+    }
+
     let proc;
     if (this.sidecarBin) {
       // Production path: a self-contained gateway binary. No Python

--- a/clawd-on-desk/src/permission.js
+++ b/clawd-on-desk/src/permission.js
@@ -459,6 +459,7 @@ function estimateBubbleHeight(sugCount) {
 
 function getAnchorWorkArea(petBounds) {
   const bounds = petBounds || ctx.getPetWindowBounds();
+  if (!bounds) return { x: 0, y: 0, width: 1920, height: 1080 };
   const cx = bounds.x + bounds.width / 2;
   const cy = bounds.y + bounds.height / 2;
   return ctx.getNearestWorkArea(cx, cy);


### PR DESCRIPTION
Fix crashes: null bounds and SOCKS proxy

1. permission.js: Add null check in getAnchorWorkArea()
2. minicpm-chat.js: Strip proxy env vars before spawning sidecar