### PR TITLE
fix Windows sidecar startup

### DIFF
--- a/minicpm-sidecar/gateway/clawd_state.py
+++ b/minicpm-sidecar/gateway/clawd_state.py
@@ -55,7 +55,7 @@ class ClawdBridge:
         self._session_id = f"minicpm-{uuid.uuid4().hex[:8]}"
         self._port: Optional[int] = None
         self._cwd = os.getcwd()
-        self._client = httpx.Client(timeout=0.4)
+        self._client = httpx.Client(timeout=0.4, trust_env=False)
 
     def new_session(self) -> None:
         with self._lock:

--- a/minicpm-sidecar/gateway/lifecycle.py
+++ b/minicpm-sidecar/gateway/lifecycle.py
@@ -151,11 +151,14 @@ def _pid_alive(pid: int) -> bool:
     the pid (no signal delivered). EPERM means the pid exists but we
     don't own it — still alive for our purposes.
 
-    On Windows, `os.kill(pid, 0)` works in CPython for live pids and
-    raises OSError for dead ones, so the same check applies.
+    On Windows, `os.kill(pid, 0)` only works reliably for child processes;
+    probing an unrelated live process can raise WinError 87. Use the Win32
+    process APIs there so an Electron parent is not mistaken for a dead pid.
     """
     if pid <= 0:
         return False
+    if platform.system() == "Windows":
+        return _windows_pid_alive(pid)
     try:
         os.kill(pid, 0)
         return True
@@ -165,6 +168,36 @@ def _pid_alive(pid: int) -> bool:
         return True
     except OSError:
         return False
+
+
+def _windows_pid_alive(pid: int) -> bool:
+    try:
+        import ctypes
+    except Exception:
+        return False
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    process_query_limited_information = 0x1000
+    still_active = 259
+    error_access_denied = 5
+    error_invalid_parameter = 87
+
+    handle = kernel32.OpenProcess(process_query_limited_information, False, int(pid))
+    if not handle:
+        err = ctypes.get_last_error()
+        if err == error_access_denied:
+            return True
+        if err == error_invalid_parameter:
+            return False
+        return False
+
+    try:
+        exit_code = ctypes.c_ulong()
+        if not kernel32.GetExitCodeProcess(handle, ctypes.byref(exit_code)):
+            return False
+        return exit_code.value == still_active
+    finally:
+        kernel32.CloseHandle(handle)
 
 
 # ── llama-server pdeathsig (Linux) ─────────────────────────────────────────

--- a/minicpm-sidecar/gateway/llama_client.py
+++ b/minicpm-sidecar/gateway/llama_client.py
@@ -327,6 +327,7 @@ class LlamaServer:
             self._client = httpx.AsyncClient(
                 base_url=f"http://{self.host}:{self.port}",
                 timeout=httpx.Timeout(connect=5.0, read=None, write=30.0, pool=5.0),
+                trust_env=False,
             )
         # Health poll outside the swap lock so /api/chat issued by Electron
         # before this returns doesn't deadlock.
@@ -366,7 +367,7 @@ class LlamaServer:
         log = get_logger()
         deadline = time.monotonic() + timeout
         last_err: Optional[Exception] = None
-        async with httpx.AsyncClient(timeout=2.0) as probe:
+        async with httpx.AsyncClient(timeout=2.0, trust_env=False) as probe:
             while time.monotonic() < deadline:
                 if self._proc and self._proc.poll() is not None:
                     tail = "\n".join(self.last_stderr[-30:]) or "(no stderr)"

--- a/minicpm-sidecar/scripts/build-llama.ps1
+++ b/minicpm-sidecar/scripts/build-llama.ps1
@@ -72,6 +72,7 @@ if ($LASTEXITCODE -ne 0) { Write-Error "cmake build failed (exit $LASTEXITCODE)"
 
 $server = $null
 foreach ($cand in @(
+  (Join-Path $build "bin\llama-server.exe"),
   (Join-Path $build "bin\Release\llama-server.exe"),
   (Join-Path $build "Release\llama-server.exe"),
   (Join-Path $build "tools\server\Release\llama-server.exe"),
@@ -91,6 +92,23 @@ New-Item -ItemType Directory -Force -Path $out | Out-Null
 Copy-Item -Force $server $out
 Get-ChildItem -Path $build -Recurse -Filter *.dll | ForEach-Object {
   Copy-Item -Force $_.FullName $out
+}
+
+$cxx = Get-Command g++ -ErrorAction SilentlyContinue
+if ($cxx) {
+  $toolchainBin = Split-Path -Parent $cxx.Source
+  foreach ($dll in @(
+    "libgcc_s_seh-1.dll",
+    "libstdc++-6.dll",
+    "libwinpthread-1.dll",
+    "libgomp-1.dll",
+    "libdl.dll"
+  )) {
+    $runtime = Join-Path $toolchainBin $dll
+    if (Test-Path $runtime) {
+      Copy-Item -Force $runtime $out
+    }
+  }
 }
 
 Write-Host "==> OK -> $out\llama-server.exe" -ForegroundColor Green


### PR DESCRIPTION
Fixes Windows development startup for the MiniCPM sidecar.

This PR addresses several Windows-specific issues:
- Use Win32 process APIs for parent PID checks so the sidecar watchdog no longer exits immediately when Electron is alive.
- Disable environment proxy usage for local `httpx` clients to avoid failures with system SOCKS proxy settings.
- Improve `build-llama.ps1` for MinGW/Ninja builds by detecting the generated `llama-server.exe` path and copying required runtime DLLs.

Tested on Windows with:
- `pytest tests/test_lifecycle.py tests/test_llama_client_payload.py tests/test_backend_selection.py`
- Local `llama-server.exe --version` startup check